### PR TITLE
Import MozQA `mixed_content_blocked` test from mozqa.com [#1414776]

### DIFF
--- a/mozqa/mixed_content_blocked/iframe.html
+++ b/mozqa/mixed_content_blocked/iframe.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <script>
-      var insecureURL = "http://no-ssl.mozqa.com/data/firefox/security/mixed_content_blocked/iframe.html";
+      var insecureURL = "https://mixed-content-tests-mozilla.org/mozqa/mixed_content_blocked/iframe.html";
       var baseURL = insecureURL.slice(0, insecureURL.lastIndexOf("/"));
 
       // load an insecure script from a secure iframe

--- a/mozqa/mixed_content_blocked/iframe.html
+++ b/mozqa/mixed_content_blocked/iframe.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      var insecureURL = "http://no-ssl.mozqa.com/data/firefox/security/mixed_content_blocked/iframe.html";
+      var baseURL = insecureURL.slice(0, insecureURL.lastIndexOf("/"));
+
+      // load an insecure script from a secure iframe
+      parent.log("Attemping to load insecure script 2.");
+      var s = document.createElement("script");
+      s.src = baseURL + "/scripts/script2.js";
+      document.head.appendChild(s);
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/mozqa/mixed_content_blocked/index.html
+++ b/mozqa/mixed_content_blocked/index.html
@@ -23,7 +23,7 @@
 
     <pre id="log"></pre>
     <script>
-      var insecureURL = "http://no-ssl.mozqa.com/data/firefox/security/mixed_content_blocked/index.html";
+      var insecureURL = "http://mixed-content-tests-mozilla.org/mozqa/mixed_content_blocked/index.html";
       var baseURL = insecureURL.slice(0, insecureURL.lastIndexOf("/"));
 
       function log(s) {

--- a/mozqa/mixed_content_blocked/index.html
+++ b/mozqa/mixed_content_blocked/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test Mixed Content Blocking</title>
+    <link rel="stylesheet" type="text/css" href="style/style.css" />
+  </head>
+  <body onload="runTests();">
+    <div class="test">
+      Insecure script 1: <span id="result1">NOT LOADED</span>
+    </div>
+
+    <div class="test">
+      Insecure script 2: <span id="result2">NOT LOADED</span>
+    </div>
+
+    <div id="plugintest" class="test">
+      Insecure plugin content: <span id="result3">NOT LOADED</span>
+    </div>
+
+    <div id="stylesheet" class="test">
+      Insecure stylesheet: <span id="result4"></span>
+    </div>
+
+    <pre id="log"></pre>
+    <script>
+      var insecureURL = "http://no-ssl.mozqa.com/data/firefox/security/mixed_content_blocked/index.html";
+      var baseURL = insecureURL.slice(0, insecureURL.lastIndexOf("/"));
+
+      function log(s) {
+        var log = document.getElementById("log");
+        log.textContent = log.textContent + s + "\n";
+      }
+
+      window.addEventListener("message", function insecureObject(event) {
+        window.removeEventListener("message", insecureObject, false);
+        log("Received message from " + event.origin + ": " + event.data);
+
+        // look for message from our <object>
+        if (event.data == "object loaded") {
+          var r = document.getElementById("result3");
+          r.textContent = "LOADED";
+          r.parentElement.className = "test fail";
+        }
+      }, false);
+
+      function runTests() {
+        // Test 1:
+        // load first insecure script
+        log("Attemping to load insecure script 1.");
+        var s = document.createElement("script");
+        s.src = baseURL + "/scripts/script1.js";
+        document.body.appendChild(s);
+
+        // Test 2:
+        // load insecure script inside an iFrame
+        log("Attemping to load insecure script inside an iFrame.");
+        var f = document.createElement("iframe");
+        f.src = "iframe.html";
+        f.id = "frame";
+        document.getElementById("result2").parentNode.appendChild(f);
+
+        // Test 3:
+        // load an insecure "plugin"
+        log("Attempting to load insecure <object> element");
+        window.addEventListener("message", function() {});
+        var o = document.createElement("object");
+        o.type = "text/html";
+        o.data = baseURL + "/scripts/object.html";
+        document.getElementById("result3").appendChild(o);
+
+        // Test 4:
+        // load an insecure stylesheet loaded
+        log("Attemping to load  insecure stylesheet status");
+        var l = document.createElement("link");
+        l.rel = "stylesheet";
+        l.type = "text/css";
+        l.href= baseURL + "/style/insecure_style.css";
+        document.head.appendChild(l);
+      }
+    </script>
+  </body>
+</html>

--- a/mozqa/mixed_content_blocked/scripts/object.html
+++ b/mozqa/mixed_content_blocked/scripts/object.html
@@ -1,0 +1,3 @@
+<script>
+  top.postMessage("object loaded", "*");
+</script>

--- a/mozqa/mixed_content_blocked/scripts/script1.js
+++ b/mozqa/mixed_content_blocked/scripts/script1.js
@@ -1,0 +1,3 @@
+var r = document.getElementById("result1");
+r.textContent = "LOADED";
+r.parentElement.className = "test fail";

--- a/mozqa/mixed_content_blocked/scripts/script2.js
+++ b/mozqa/mixed_content_blocked/scripts/script2.js
@@ -1,0 +1,4 @@
+var r = top.document.getElementById("result2");
+r.textContent = "LOADED";
+r.parentElement.className = "test fail";
+top.document.getElementById("frame").parentElement.className = "test fail";

--- a/mozqa/mixed_content_blocked/style/insecure_style.css
+++ b/mozqa/mixed_content_blocked/style/insecure_style.css
@@ -1,0 +1,8 @@
+#stylesheet {
+  border-color: red;
+  color: red;
+}
+
+#result4::before {
+  content: "LOADED";
+}

--- a/mozqa/mixed_content_blocked/style/style.css
+++ b/mozqa/mixed_content_blocked/style/style.css
@@ -1,0 +1,23 @@
+.test {
+  color: #080;
+  margin: 1em;
+  padding: 1em;
+  border: 1px solid #080;
+  border-radius: 5px;
+  min-width: 250px;
+}
+
+.fail {
+  border-color: red;
+  color: red;
+}
+
+iframe {
+  vertical-align: middle;
+  border: none;
+  min-width: 350px;
+}
+
+#result4::before {
+  content: "NOT LOADED";
+}


### PR DESCRIPTION
Originally at https://hg.mozilla.org/qa/testcase-data/file/tip/firefox/security/mixed_content_blocked and being migrated as part of bug 1414776.